### PR TITLE
Cambios en como se leen las keys y agrega TLS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+.git

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .env
-*.key
-*.key.pub
+keys/*.key
+keys/*.key.pub
+certs/*.key
+certs/*.cert
 
 # Logs
 logs

--- a/Courses.postman_collection.json
+++ b/Courses.postman_collection.json
@@ -7,7 +7,27 @@
 	},
 	"item": [
 		{
-			"name": "localhost:8080/Course/",
+			"name": "Health Check",
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "HEAD",
+				"header": [],
+				"url": {
+					"raw": "{{url}}/",
+					"host": [
+						"{{url}}"
+					],
+					"path": [
+						""
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Status",
 			"request": {
 				"auth": {
 					"type": "noauth"
@@ -15,11 +35,27 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "localhost:8080/Course/",
+					"raw": "{{url}}/",
 					"host": [
-						"localhost"
+						"{{url}}"
 					],
-					"port": "8080",
+					"path": [
+						""
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "/Course",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{url}}/Course/",
+					"host": [
+						"{{url}}"
+					],
 					"path": [
 						"Course",
 						""
@@ -29,13 +65,13 @@
 			"response": []
 		},
 		{
-			"name": "localhost:8080/Course/",
+			"name": "/Course",
 			"request": {
 				"method": "POST",
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"name\": \"Diplomatura Desarrollo Seguro de App - 4ta. edición\",\n    \"initDate\": \"2023-03-05T03:00:00.000Z\",\n    \"enrolled\": 0\n}",
+					"raw": "{\n    \"name\": \"Diplomatura Desarrollo Seguro de App - 4ta. edición\",\n    \"initDate\": \"2023-03-05T03:00:00.000Z\",\n    \"enrolled\": 19\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -43,11 +79,10 @@
 					}
 				},
 				"url": {
-					"raw": "localhost:8080/Course/",
+					"raw": "{{url}}/Course/",
 					"host": [
-						"localhost"
+						"{{url}}"
 					],
-					"port": "8080",
 					"path": [
 						"Course",
 						""
@@ -57,16 +92,15 @@
 			"response": []
 		},
 		{
-			"name": "localhost:8080/Course/de47e087-4736-4733-ad67-12f71371636e",
+			"name": "/Course/:id",
 			"request": {
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "localhost:8080/Course/de47e087-4736-4733-ad67-12f71371636e",
+					"raw": "{{url}}/Course/de47e087-4736-4733-ad67-12f71371636e",
 					"host": [
-						"localhost"
+						"{{url}}"
 					],
-					"port": "8080",
 					"path": [
 						"Course",
 						"de47e087-4736-4733-ad67-12f71371636e"
@@ -76,13 +110,13 @@
 			"response": []
 		},
 		{
-			"name": "localhost:8080/Course/de47e087-4736-4733-ad67-12f71371636e Copy",
+			"name": "/Course/:id",
 			"request": {
 				"method": "PUT",
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"id\": \"de47e087-4736-4733-ad67-12f71371636e\",\n    \"name\": \"Diplomatura Desarrollo Seguro de App - 2da. edición\",\n    \"initDate\": \"2022-08-20T03:00:00.000Z\",\n    \"enrolled\": 25\n}",
+					"raw": "{\n    \"id\": \"de47e087-4736-4733-ad67-12f71371636e\",\n    \"name\": \"Diplomatura Desarrollo Seguro de App - 2da. edición\",\n    \"initDate\": \"2022-08-20T03:00:00.000Z\",\n    \"enrolled\": 28\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -90,11 +124,10 @@
 					}
 				},
 				"url": {
-					"raw": "localhost:8080/Course/de47e087-4736-4733-ad67-12f71371636e",
+					"raw": "{{url}}/Course/de47e087-4736-4733-ad67-12f71371636e",
 					"host": [
-						"localhost"
+						"{{url}}"
 					],
-					"port": "8080",
 					"path": [
 						"Course",
 						"de47e087-4736-4733-ad67-12f71371636e"
@@ -104,19 +137,18 @@
 			"response": []
 		},
 		{
-			"name": "localhost:8080/Course/de47e087-4736-4733-ad67-12f71371636e Copy 2",
+			"name": "/Course/:id",
 			"request": {
 				"method": "DELETE",
 				"header": [],
 				"url": {
-					"raw": "localhost:8080/Course/907b9a75-7d64-41e4-aad7-f82939c5a566",
+					"raw": "{{url}}/Course/b95468b7-796e-470b-b668-e75cbdf833d8",
 					"host": [
-						"localhost"
+						"{{url}}"
 					],
-					"port": "8080",
 					"path": [
 						"Course",
-						"907b9a75-7d64-41e4-aad7-f82939c5a566"
+						"b95468b7-796e-470b-b668-e75cbdf833d8"
 					]
 				}
 			},
@@ -140,11 +172,10 @@
 					}
 				},
 				"url": {
-					"raw": "localhost:8080/token",
+					"raw": "{{url}}/token",
 					"host": [
-						"localhost"
+						"{{url}}"
 					],
-					"port": "8080",
 					"path": [
 						"token"
 					]
@@ -162,7 +193,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\"grant_type\": \"client_credentials\", \"client_id\": \"6f0177f9-5d8f-4387-b546-00d8dfc05cfa\", \"client_secret\": \"TfQNnL7aC9aNTLZHAP1OIGz-QXAw447xjXEI\"}",
+					"raw": "{\"grant_type\": \"client_credentials\", \"client_id\": \"43dd1932-2618-4d6b-9faa-0038910002d9\", \"client_secret\": \"ZIMSCz-yNJJZ9wKyPjUJbDp44a1xTQV5jbYj\"}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -170,11 +201,10 @@
 					}
 				},
 				"url": {
-					"raw": "localhost:8080/token",
+					"raw": "{{url}}/token",
 					"host": [
-						"localhost"
+						"{{url}}"
 					],
-					"port": "8080",
 					"path": [
 						"token"
 					]
@@ -189,7 +219,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{ \"app\": \"curzazo\" }",
+					"raw": "{ \"app\": \"cursote\" }",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -197,13 +227,32 @@
 					}
 				},
 				"url": {
-					"raw": "localhost:8080/Client",
+					"raw": "{{url}}/Client",
 					"host": [
-						"localhost"
+						"{{url}}"
 					],
-					"port": "8080",
 					"path": [
 						"Client"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get b64 jwt pub key",
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{url}}/jwtpubkey",
+					"host": [
+						"{{url}}"
+					],
+					"path": [
+						"jwtpubkey"
 					]
 				}
 			},
@@ -215,7 +264,7 @@
 		"bearer": [
 			{
 				"key": "token",
-				"value": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InJmb3J0IiwiaWF0IjoxNjY5ODY5OTk1LCJleHAiOjE2Njk4NzExOTV9.RtxcMqOVCSyhKUzyA8cdhE9Z1-QdIb-OpFzWc3HJwWN37C98F1LKh_xu7dO7Vvy61DeaU2sAbtJxEFwvpXluOI455PicyvgIerFEL8APHAN671fLPRhksTaX60wXb6lqCLXheVuHgPvuO8LrgE-gMKPlsSSUagE25Wb4uxj2dFlZ8M6gaWfjzFB3mqp5HWuEfW5olFVaRsTxJMZtADj9MV7khr5cBzNWSJfLxTbyQz6j_3oBheQXKMDeK322xrOnhYlbo4nsybsxQony75N78FTwJhwvWBsGXpveuk8B9XwCykbu0oEFhBarC3VOLT5wFfjltyhWi4_Vqg3NWx-IwdvVGBqRw1GhrW8BTV1YoGA9QMPuacNduBpeXwtc7ZshtXnXmjWiQaussRejK1nZOLNffT1REPF3AP3ZL7ka78Mp6dEhXvgYUft-12bUt38Gqi6icdrqpS-K2SeBre2eO28nCM6ALRh5aM9tses2qaC9KkV5fWoIUcqM_bAxBiUamhUxSYdUI2Lj27-Jwwt9WXftpoJLIqXncO45afsJ3gfyhWE1-rXhDv99zmqIOMh6m16pfErfw6gk5zSxi6K093XM2mor3BCP5fdx2AhdMbdbb5UFjRAwXsBojyBNz_zKi_uGhjX4WQKbLAlF2rvyD1RXCp-gFtNJKM9OYYL4siQ",
+				"value": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6Im5iYXJyZXJhIiwiaWF0IjoxNjY5ODY3NTY2LCJleHAiOjE2Njk4Njc4NjZ9.mP6cRYUoyY7XQvFrPSpwylKQV8ttzNAYdonV5wZRPq4BSm9b9QRKiuYDBxlEiDwuFRcRFTPu-JOVO5ZmCXWnnanS3UydXceKmCdT7CHJHlIg7ayWrGrlLa58P8M7u9bFk2NVVeYWN890PDKu3-bVfuOXjPaQak-KGtfORrr_6JRXGNGST9EopCrAfpVQYN7orApIJ10yAIK_QgJGp6s0Q0ez4W_F9Iee--nueKxx25V9vKEv4OOFc9s9wwiSYXesTUckMB5xUZvjJwf1a0MB_MKh-VRUptLuJ8asC-OaVMsa4VC42e4DjLfUeeg32DBHjh_6DB-jq2FL3cw5L6Ti2lEAN17g6EWtP_jE1CiaxZhfODdZ-xiK09VSaNzDnMMkG8SfKtNoyLDAMdW8E-RlG-MkGxXpo_37-ius2Q9tRN2cPEyQRWW9NVjYmLXSYBWU7wg2XrNtoCM4kyFF1IOi-7RUPbBgkGt3AyEUX___PzwArLDsf8XxBxefsSuf7j7zSGAPLztDAjHSkNChmb5Ql6kUh7_NtzKzH7yMGHE1uH7sll3Jst-JtLY602Sh8jQEVeQkKziJbqmUtlFVL-K632eDGJR9cWeK9LSujK4ux3GYUF_WW0x-DY5f4zUdCwJxJbOv3zXxsw7RQo07KUCTwwX8aZD23DGp6RX0uMrRANo",
 				"type": "string"
 			}
 		]
@@ -244,6 +293,11 @@
 		{
 			"key": "toRemove",
 			"value": "907b9a75-7d64-41e4-aad7-f82939c5a566"
+		},
+		{
+			"key": "url",
+			"value": "https://localhost:8080",
+			"type": "string"
 		}
 	]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 # TODO: cambiar esta imagen por una mas segura
-FROM node:18
+FROM node:18-alpine
+
+# Upgrade alpine packages
+RUN apk -U upgrade
 
 # Create app directory
 WORKDIR /usr/src/app
@@ -9,12 +12,14 @@ WORKDIR /usr/src/app
 # where available (npm@5+)
 COPY package*.json ./
 
-RUN npm install
+# RUN npm install
 # If you are building your code for production
-# RUN npm ci --only=production
+RUN npm ci --only=production --omit=dev
 
 # Bundle app source
 COPY . .
 
+RUN chown -R node:node .
+USER node
 EXPOSE 8080
 CMD [ "node", "server.js" ]

--- a/README.md
+++ b/README.md
@@ -2,34 +2,30 @@
 
 ## SETUP
 
-### Install
+### Claves de encriptado
+
+El JWT de la API es firma utilizando una clave privada que es necesario configurar antes de
+arrancar el servidor.
+
+Los detalles sobre la configuracion de la clave estan en el archivo `keys/README.md`
+
+### Docker
+
+Guardar las claves y certificados en su directorio y buildear la imagen.
+
+La imagen expone el puerto 8080 con https.
+
+### Local
+
+#### Install
 
 ```
 npm install
 ```
 
-### Claves RSA para firmar el JWT
 
-**Dejar passphrase en blanco!**
 
-#### Clave privada
-```
-ssh-keygen -t rsa -b 4096 -m PEM -f jwtRS256.key
-```
-
-#### Clave publica
-```
-openssl rsa -in jwtRS256.key -pubout -outform PEM -out jwtRS256.key.pub
-```
-
-#### Guardar las claves en el archivo .env encodeadas en base64
-
-```
-cat jwtRS256.key | base64 | sed 's/^/JWT_RS256_PRIV_B64="/' | sed 's/$/"/' >> .env
-cat jwtRS256.key.pub | base64 | sed 's/^/JWT_RS256_PUB_B64="/' | sed 's/$/"/' >> .env
-```
-
-## RUN
+#### RUN
 
 ```
 npm start
@@ -49,7 +45,14 @@ Open `http://localhost:8080/api-docs`
 
 Import `Courses.postman_collection.json` on postman.
 
+### Permitir Certificado Self-Signed
+
+Hay que abrir la configuracion de Postman y cambiar la opcion de validacion de certificado, de lo contrario los pedidos de Postman no se enviaran.
+
+La otra opcion seria hacer que el sistema operativo confie en el certificado auto firmado de la api de cursos meidante una configuracion que depende del sistema operativo en uso.
+
+
 ## TODO
 - [x] validar inputs
-- [ ] revisar el dockerfile, encontrar una imagen con menos vulnerabilidades
+- [x] revisar el dockerfile, encontrar una imagen con menos vulnerabilidades
 - [x] meter un action en el repo que escanee el dockerfile?

--- a/README.md
+++ b/README.md
@@ -53,6 +53,19 @@ Hay que abrir la configuracion de Postman y cambiar la opcion de validacion de c
 
 La otra opcion seria hacer que el sistema operativo confie en el certificado auto firmado de la api de cursos meidante una configuracion que depende del sistema operativo en uso.
 
+## SOLUCION DE PROBLEMAS
+
+### KeyMgr error
+
+Si al intentar levantar el servidor ocurre el siguiente error
+
+```
+KeyMgr error
+```
+
+El problema se soluciona revisando que los archivos de keys y de certs se encuentren en los directorios correspondientes y que los archivos tengan el nombre que corresponde.
+
+Para revisar estos datos se puede consultar este mismo README.md o el de ./keys/README.md y ./certs/README.md
 
 ## TODO
 - [x] validar inputs

--- a/README.md
+++ b/README.md
@@ -17,33 +17,32 @@ La imagen expone el puerto 8080 con https.
 
 ### Local
 
-#### Install
+#### Instalar
 
 ```
 npm install
 ```
 
 
-
-#### RUN
+#### EJECUTAR
 
 ```
 npm start
 ```
 
-or using debug log level
+o usando el log de debug:
 
 ```
 DEBUG=course:* npm start
 ```
 
-## READ API DOCS
+## API DOCS
 
-Open `http://localhost:8080/api-docs`
+Levantar el server y abrir en el navegador: `https://localhost:8080/api-docs`
 
-## TEST WITH POSTMAN
+## PROBAR CON POSTMAN
 
-Import `Courses.postman_collection.json` on postman.
+Importar `Courses.postman_collection.json` con postman.
 
 ### Permitir Certificado Self-Signed
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Import `Courses.postman_collection.json` on postman.
 
 Hay que abrir la configuracion de Postman y cambiar la opcion de validacion de certificado, de lo contrario los pedidos de Postman no se enviaran.
 
+![dev](https://user-images.githubusercontent.com/1416695/205656729-40189d9d-8298-46a0-8d92-25c376c8e42d.gif)
+
+
 La otra opcion seria hacer que el sistema operativo confie en el certificado auto firmado de la api de cursos meidante una configuracion que depende del sistema operativo en uso.
 
 

--- a/api.yml
+++ b/api.yml
@@ -4,7 +4,7 @@ info:
   title: Courses API
   version: 1.0.0
 servers:
-- url: http://localhost:8080
+- url: https://localhost:8080
 components:
   securitySchemes:
     bearerAuth:
@@ -107,6 +107,7 @@ components:
           type: string
           $ref: "#/components/schemas/UUID"
         client_secret:
+          description: This should be the plainSecret obtained from POST /Client. The clientSecret porperty in that response is hashed as stored in DB so it won't work!
           type: string
 
   responses:
@@ -347,9 +348,26 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/responses/CourseResponse"
+  "/jwtpubkey":
+    get:
+      description: Get the base 64 encoded public key used to signthe jwt to verify authenticity of jwt.
+      security: []
+      responses:
+        200:
+          description: returns an object with the b64 pub key in a prop
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jwtpubkeyB64:
+                    type: string
+
   "/token":
     post:
       description: Initialize the Resource Owner Password or Client Credentials OAUTH Flows.
+        NOTE! If you are tring Client Credentials be sure to pass the plainSecret you obtained from
+        the POST /Client endpoint, not clientSecret BUT plainSecret.
       security: []
       requestBody:
         required: true

--- a/auth/KeyMgr.js
+++ b/auth/KeyMgr.js
@@ -1,0 +1,46 @@
+import { readFileSync } from 'fs'
+import { join, dirname } from 'path'
+
+const PUB_KEY_PATH = join(dirname('.'), 'keys', 'jwtRS256.key.pub')
+const PRI_KEY_PATH = join(dirname('.'), 'keys', 'jwtRS256.key')
+
+const CERT_PATH = join(dirname('.'), 'certs', 'https.cert')
+const CERT_KEY_PATH = join(dirname('.'), 'certs', 'https.key')
+
+class KeyMgr {
+  init() {
+    try {
+      this.pubkey = readFileSync(PUB_KEY_PATH, { encoding: 'utf-8' })
+      this.prikey = readFileSync(PRI_KEY_PATH, { encoding: 'utf-8' })
+      console.info(`Read keys ok.`)
+
+      this.cert = readFileSync(CERT_PATH, { encoding: 'utf-8' })
+      this.certkey = readFileSync(CERT_KEY_PATH, { encoding: 'utf-8' })
+      console.info(`Cert and cert key ok.`)
+    } catch(e) {
+      throw new Error(`ERROR: Reading public and private keys files. Those should be on the ./keys directory with a specific name check README.md and keys/README.md\nerr: ${e.message}\nstack: ${e.stack}`)
+    }
+  }
+
+  getPubKey() {
+    return this.pubkey
+  }
+  getPubKeyB64() {
+    return Buffer.from(this.getPubKey(), 'utf-8').toString('base64')
+  }
+
+  getPriKey() {
+    return this.prikey
+  }
+
+  getCert() {
+    return this.cert
+  }
+  getCertKey() {
+    return this.certkey
+  }
+
+
+}
+
+export default new KeyMgr()

--- a/auth/KeyMgr.js
+++ b/auth/KeyMgr.js
@@ -18,7 +18,7 @@ class KeyMgr {
       this.certkey = readFileSync(CERT_KEY_PATH, { encoding: 'utf-8' })
       console.info(`Cert and cert key ok.`)
     } catch(e) {
-      throw new Error(`ERROR: Reading public and private keys files. Those should be on the ./keys directory with a specific name check README.md and keys/README.md\nerr: ${e.message}\nstack: ${e.stack}`)
+      throw new Error(`KeyMgr error`)
     }
   }
 

--- a/auth/api-auth.js
+++ b/auth/api-auth.js
@@ -1,3 +1,4 @@
+import { readFileSync } from 'fs'
 import passport from 'passport'
 import { Strategy as BearerStrategy } from 'passport-http-bearer'
 import { Strategy as ClientCredentialsStrategy } from 'passport-oauth2-client-password'
@@ -7,6 +8,7 @@ import limiter from '../ratelimit/limiter.js'
 import { getClient, verifySecret } from '../clients/db.js'
 import { getToken } from '../tokens/db.js'
 import { getUser } from '../users/db.js'
+import KeyMgr from './KeyMgr.js'
 
 const redactUser = user => {
   delete user.password
@@ -20,6 +22,9 @@ const redactClient = client => {
 // setup api auth
 export default app => {
 
+  app.get('/jwtpubkey', (req, res) => {
+    res.json({ jwtpubkeyB64: KeyMgr.getPubKeyB64() })
+  })
   app.post("/token",
     limiter, // rate limit this endpoint
     authServer.token(),

--- a/auth/auth-server.js
+++ b/auth/auth-server.js
@@ -4,12 +4,7 @@ import jwt from 'jsonwebtoken'
 import { getUser, verifyPassword } from '../users/db.js'
 import { getClient, verifySecret } from '../clients/db.js'
 import { saveToken } from '../tokens/db.js'
-
-if (!process.env.JWT_RS256_PRIV_B64) {
-  console.error(`ERROR! Please configure the JWT_RS256_PRIV_B64 env var with an base64 encoded RS256 private key.`)
-  throw new Error('Setup env var JWT_RS256_PRIV_B64 env var with an base64 encoded RS256 private key')
-}
-const privateKey = Buffer.from(process.env.JWT_RS256_PRIV_B64, 'base64').toString('ascii')
+import KeyMgr from './KeyMgr.js'
 
 const authServer = oauth2orize.createServer()
 
@@ -45,7 +40,7 @@ authServer.exchange(
 const makeToken = (payload, expiresIn) => jwt.sign(
   payload,
   // sign with RSA SHA256
-  privateKey,
+  KeyMgr.getPriKey(),
   { algorithm: 'RS256', expiresIn }
 )
 

--- a/certs/README.md
+++ b/certs/README.md
@@ -1,0 +1,8 @@
+# Certificado y clave para SSL
+
+Si recibiste el certificado y la clave privada del certificado agregalos en este directorio con los siguientes nombres:
+
+* `https.cert` para el certificado
+* `https.key` para la clave privada del certificado
+
+**Importante: asegurarse que los archivos de claves esten en este directorio con el nombre correcto, porque sino el servidor no arranca.**

--- a/courses/entities/course.js
+++ b/courses/entities/course.js
@@ -1,0 +1,8 @@
+export class Course {
+  constructor({ id, name, initDate, enrrolled }) {
+    this.id = id;
+    this.name = name;
+    this.initDate = initDate;
+    this.enrrolled = enrrolled;
+  }
+}

--- a/courses/routes.js
+++ b/courses/routes.js
@@ -7,6 +7,8 @@ import {
   updateCourse,
 } from "./db.js";
 import passport from 'passport'
+import sanitizer from 'sanitize'
+import { Course } from './entities/course.js'
 
 const router = express.Router();
 
@@ -18,8 +20,9 @@ router.get("/",
 )
 
 router.get("/:id", passport.authenticate('bearer', { session: false }), (req, res) => {
-  const course = getCourse(req.params.id);
-
+  const id = sanitizer.value(req.params.id, 'string');
+  const data = getCourse(id);
+  const course = new Course(data)
   if (course) {
     res.json(course);
   } else {
@@ -28,19 +31,22 @@ router.get("/:id", passport.authenticate('bearer', { session: false }), (req, re
 });
 
 router.post("/", passport.authenticate('bearer', { session: false }), (req, res) => {
-  const course = req.body;
+  const course = new Course(req.body);
   const savedCourse = addCourse(course);
 
   res.json(savedCourse);
 });
 
 router.put("/:id", passport.authenticate('bearer', { session: false }), (req, res) => {
-  const course = updateCourse(req.params.id, req.body);
-  res.json(course);
+  const id = sanitizer.value(req.params.id, 'string');
+  const course = new Course(req.body);
+  const updatedCourse = new Course(updateCourse(id, course));
+  res.json(updatedCourse);
 });
 
 router.delete("/:id", passport.authenticate('bearer', { session: false }), (req, res) => {
-  removeCourse(req.params.id);
+  const id = sanitizer.value(req.params.id, 'string');
+  removeCourse(id);
   return res.json({ status: "ok" });
 });
 

--- a/courses/routes.js
+++ b/courses/routes.js
@@ -18,7 +18,6 @@ router.get("/",
 )
 
 router.get("/:id", passport.authenticate('bearer', { session: false }), (req, res) => {
-  // TODO: Validar el input
   const course = getCourse(req.params.id);
 
   if (course) {
@@ -30,21 +29,17 @@ router.get("/:id", passport.authenticate('bearer', { session: false }), (req, re
 
 router.post("/", passport.authenticate('bearer', { session: false }), (req, res) => {
   const course = req.body;
-  // TODO: Validar el input
   const savedCourse = addCourse(course);
 
   res.json(savedCourse);
 });
 
 router.put("/:id", passport.authenticate('bearer', { session: false }), (req, res) => {
-  // TODO: Validar el input
-  // TODO: validar no se puede cambiar el id del curso
   const course = updateCourse(req.params.id, req.body);
   res.json(course);
 });
 
 router.delete("/:id", passport.authenticate('bearer', { session: false }), (req, res) => {
-  // TODO: Validar el input
   removeCourse(req.params.id);
   return res.json({ status: "ok" });
 });

--- a/keys/README.md
+++ b/keys/README.md
@@ -1,0 +1,24 @@
+# Claves RSA para firmar el JWT
+
+Si recibiste las claves guardarlas en este directorio con los siguientes nombres:
+
+* `jwtRS256.key` para la clave privada
+* `jwtRS256.key.pub` para la clave publica
+
+Si no las recibiste, o queres usar nuevas claves podes crear unas nuevas asi:
+
+**Dejar passphrase en blanco!**
+
+## Clave privada
+```
+ssh-keygen -t rsa -b 4096 -m PEM -f jwtRS256.key
+```
+
+## Clave publica
+```
+openssl rsa -in jwtRS256.key -pubout -outform PEM -out jwtRS256.key.pub
+```
+
+**Importante: asegurarse que los archivos de claves esten en este directorio con el nombre correcto, porque sino el servidor no arranca.**
+
+En verdad solo se esta utilizando la clave privada, la clave publica puede ser util tenerla para servirla de manera que los clientes puedan verificar la autenticidad del token.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "passport-http": "^0.3.0",
     "passport-http-bearer": "^1.0.1",
     "passport-oauth2-client-password": "^0.1.2",
+    "sanitize": "^2.1.2",
     "swagger-ui-express": "^4.6.0",
     "yamljs": "^0.3.0"
   },


### PR DESCRIPTION
* mejora la imagen (a lo CSI) de docker usando alpine linux y actualizando paquetes
* se cambia de donde se obtienen los cetiicados y claves, ahora siempre es desde un directorio
* se habilita TLS con un cetificado auto firmado
* se agrega un endpoint para obtener la clave publica de la firma jwt
* ⚠️  se actualiza la collection de postman, uso una variable para la url... sirve para pasar de http a https pero tambien si lo corro local en el 8080 o si lo corro en la docker instance y mapeo  a otro puerto (ej: `-p 8081:8080`)